### PR TITLE
Updated jenkins-ptcs-library from 0.5.0 to 0.6.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library 'jenkins-ptcs-library@0.5.0'
+library 'jenkins-ptcs-library@0.6.0'
 
 podTemplate(label: pod.label,
   containers: pod.templates + [


### PR DESCRIPTION
Closes #19