### PR TITLE
Updated readme with example how to run standalone at docker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,16 @@ Key aspects:
 
 See [Api description document](ApiDescription.md)
 
+## Testing locally in docker
+
+Easiest way to run and test application is to start in with docker
+
+```bash
+docker run -it -p 5000:5000 -e ASPNETCORE_ENVIRONMENT=Development ptcos/pdf-storage
+```
+
+Navigate to [http://localhost:5000/doc](http://localhost:5000/doc)
+
 ## Running locally for development
 
 Install .NET core SDK.


### PR DESCRIPTION
Easiest way to test storage should not require net core SDK. Added example how to start as standalone with only docker.