### PR TITLE
Fix: Set AWS S3 service url only if defined in appsettings

### DIFF
--- a/Config/AwsS3Config.cs
+++ b/Config/AwsS3Config.cs
@@ -5,7 +5,7 @@ namespace Pdf.Storage.Config
         public string AwsS3BucketName { get; set; } = "pdf-storage-master";
         public string AccessKey { get; set; } = "thisisaccesskey";
         public string SecretKey { get; set; } = "ThisIsSecretKey";
-        public string AwsServiceURL { get; set; } = "http://localhost:900";
-        public string AwsRegion { get; set; } = "EUCentral1";
+        public string AwsServiceURL { get; set; }
+        public string AwsRegion { get; set; } = "us-east-1";
     }
 }

--- a/Pdf/PdfStores/AwsS3Storage.cs
+++ b/Pdf/PdfStores/AwsS3Storage.cs
@@ -21,13 +21,17 @@ namespace Pdf.Storage.Pdf
                 .ToList()
                 .SingleOrDefault(x => x.SystemName == options.Value.AwsRegion)
                 ?? throw new InvalidOperationException($"Cannot resolve {nameof(options.Value.AwsRegion)} ({options.Value.AwsRegion}) from valid options {String.Join(", ", RegionEndpoint.EnumerableAllRegions.Select(x => x.SystemName))}");
-
+                        
             var config = new AmazonS3Config
             {
                 RegionEndpoint = region,
-                ServiceURL = options.Value.AwsServiceURL ?? throw new InvalidOperationException($"Missing configuration {nameof(options.Value.AwsServiceURL)}"),
                 ForcePathStyle = true
             };
+
+            if (options.Value.AwsServiceURL != null)
+            {
+                config.ServiceURL = options.Value.AwsServiceURL;
+            }
 
             this.s3Client = new AmazonS3Client(
                 options.Value.AccessKey ?? throw new InvalidOperationException($"Missing configuration {nameof(options.Value.AccessKey)}"),

--- a/appsettings.json
+++ b/appsettings.json
@@ -18,8 +18,7 @@
   "AwsS3": {
     "AwsS3BucketName": "pdf-storage-master",
     "AccessKey": "thisisaccesskey",
-    "SecretKey": "ThisIsSecretKey",
-    "AwsServiceURL": "http://localhost:9000"
+    "SecretKey": "ThisIsSecretKey"
   },
   "AzureStorage": {
     "StorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=[your_account];AccountKey=[your_key];EndpointSuffix=core.windows.net",


### PR DESCRIPTION
Use actual S3 endpoint urls defined by the `aws-sdk-net`. Reserve the configuration for ie. configuring https://min.io/

Closes #17 