### PR TITLE
Fix for invalid chromium version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 nohup.out
 .local-chromium/
+/bin/
+/obj/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2.401-alpine3.8 as dotnetBuild
-
-COPY ./ /src/
-WORKDIR /src/
-
-RUN dotnet publish -c release -o /out
-
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2.4-alpine3.8
-
 # ! IMPORTANT: Keep chromium version synced with version from package 'PuppeteerSharp'
 # and match it with from https://pkgs.alpinelinux.org/packages
+ARG chromium_version=77.0.3865.90-r0
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2.401-alpine3.8 as dotnetBuild
+ARG chromium_version
+
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
   && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
@@ -22,10 +18,38 @@ RUN \
     libjpeg-turbo-utils \
     udev \
     ttf-opensans \
-    chromium=77.0.3865.90-r0 \
+    chromium=${chromium_version} \
     libgdiplus \
-    pdftk \
-  && rm -rf /var/cache/apk/* /tmp/*
+    pdftk
+
+COPY ./ /src/
+WORKDIR /src/
+
+ENV PuppeteerChromiumPath=/usr/bin/chromium-browser
+
+RUN dotnet publish -c release -o /out
+
+RUN dotnet test
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2.4-alpine3.8
+ARG chromium_version
+
+RUN \
+echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk --no-cache  update \
+  && apk --no-cache  upgrade \
+  && apk add --no-cache --virtual .build-deps \
+    gifsicle \
+    pngquant \
+    optipng \
+    libjpeg-turbo-utils \
+    udev \
+    ttf-opensans \
+    chromium=${chromium_version} \
+    libgdiplus \
+    pdftk
 
 # Tells software that it is running in container and have all requirements pre-installed.
 ENV PuppeteerChromiumPath=/usr/bin/chromium-browser

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
     libjpeg-turbo-utils \
     udev \
     ttf-opensans \
-    chromium=76.0.3809.132-r0 \
+    chromium=77.0.3865.90-r0 \
     libgdiplus \
     pdftk \
   && rm -rf /var/cache/apk/* /tmp/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,27 +11,6 @@ podTemplate(label: pod.label,
       stage('Checkout') {
          checkout scm
       }
-      stage('Prepare') {
-        container('dotnet') {
-          sh """
-            echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
-            && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-            && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-            && apk --no-cache  update \
-            && apk --no-cache  upgrade \
-            && apk add --no-cache --virtual .build-deps \
-              gifsicle \
-              pngquant \
-              optipng \
-              libjpeg-turbo-utils \
-              udev \
-              ttf-opensans \
-              chromium=77.0.3865.90-r0 \
-              libgdiplus \
-              pdftk
-          """
-        }
-      }
       stage('Build') {
         container('dotnet') {
           sh """
@@ -39,15 +18,7 @@ podTemplate(label: pod.label,
           """
         }
       }
-      stage('Test') {
-        container('dotnet') {
-          sh """
-            ls /usr/bin/chromium-browser
-            PuppeteerChromiumPath=/usr/bin/chromium-browser dotnet test
-          """
-        }
-      }
-      stage('Package') {
+      stage('Package & Test') {
         container('docker') {
           def publishedImage = publishContainerToGcr(project);
           publishTagToDockerhub(project);

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ podTemplate(label: pod.label,
               libjpeg-turbo-utils \
               udev \
               ttf-opensans \
-              chromium=76.0.3809.132-r0 \
+              chromium=77.0.3865.90-r0 \
               libgdiplus \
               pdftk
           """

--- a/Pdf.Storage.csproj
+++ b/Pdf.Storage.csproj
@@ -45,7 +45,7 @@
     <!--  When you update PuppeteerSharp you must also find corresponding version
           in alpine at Dockerfile. Alpine limits available chromium versions available so don't update
           this without check them out. Chromium version must be about same as puppeteer expects -->
-    <PackageReference Include="PuppeteerSharp" Version="1.17.0" />
+    <PackageReference Include="PuppeteerSharp" Version="1.19.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/ChromiumFixtureCollection.cs
+++ b/Test/ChromiumFixtureCollection.cs
@@ -1,8 +1,6 @@
 using Pdf.Storage.Test.Utils;
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = -1)]
-
 namespace Pdf.Storage.Test
 {
     [CollectionDefinition(Name)]

--- a/Test/ChromiumFixtureCollection.cs
+++ b/Test/ChromiumFixtureCollection.cs
@@ -1,6 +1,8 @@
 using Pdf.Storage.Test.Utils;
 using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = -1)]
+
 namespace Pdf.Storage.Test
 {
     [CollectionDefinition(Name)]


### PR DESCRIPTION
Core problem: only edge release of alpine have new enough version of chromium to puppeteer. However version of chromium at edge move forward and puppeteer requires very specific version of chromium so it will (and should during build) break when specified version isn't available.

This can be fixed once stable version of alpine has chromium (76+) version available. Currently newest is 73 in 3.10 branch.

Status can be checked from https://pkgs.alpinelinux.org/packages

Another aproach is to ditch alpine and change to debian based base image, alpine package version pinning is pain.